### PR TITLE
Removing ID Token Requirements from Backend Workflows

### DIFF
--- a/.github/workflows/10-backend-unit.yml
+++ b/.github/workflows/10-backend-unit.yml
@@ -17,7 +17,6 @@ on:
 permissions:
   contents: write
   pages: write
-  id-token: write
   pull-requests: read
 
     

--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -17,7 +17,6 @@ on:
 permissions:
   contents: write
   pages: write
-  id-token: write
   pull-requests: read
 
 jobs:

--- a/.github/workflows/13-backend-incremental-pitest.yml
+++ b/.github/workflows/13-backend-incremental-pitest.yml
@@ -17,7 +17,6 @@ on:
 permissions:
   contents: write
   pages: write
-  id-token: write
   pull-requests: read
   actions: read
 

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -17,7 +17,6 @@ on:
 permissions:
   contents: write
   pages: write
-  id-token: write
   pull-requests: read
   actions: read
 


### PR DESCRIPTION
It appears that the backend workflows request an ID token permission that goes unused through their run and will cause fails unless the permission is specifically requests in the calling workflows. As a result, I remove them.

Example of the workflows properly running is visible here:

https://github.com/ucsb-cs156-f25/STARTER-team01/pull/18

The workflow tweak commits on the linked PR should be reverted if this PR is merged.
