### PR TITLE
Add WEBHOOK_SECRET input to validate-db-schema workflow

### DIFF
--- a/.github/workflows/18-validate-db-schema.yml
+++ b/.github/workflows/18-validate-db-schema.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
         default: 'temurin'
+      WEBHOOK_SECRET:
+        required: false
+        type: string
+        default : ''
 
 permissions:
   contents: write
@@ -33,6 +37,8 @@ jobs:
          cache-dependency-path: 'pom.xml' 
   
     - name: Build with Maven
+      env:
+        WEBHOOK_SECRET: ${{ inputs.WEBHOOK_SECRET }}
       run: | 
         mvn -ntp spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.hibernate.ddl-auto=validate"&
         SERVER_PROCESS_ID=$!

--- a/.github/workflows/18-validate-db-schema.yml
+++ b/.github/workflows/18-validate-db-schema.yml
@@ -16,7 +16,7 @@ on:
       WEBHOOK_SECRET:
         required: false
         type: string
-        default : ''
+        default: ''
 
 permissions:
   contents: write


### PR DESCRIPTION
In this PR, I allow the passing of WEBHOOK_SECRET as a parameter to `18-validate-db-schema.yml`. This allows us to actually start frontiers and validate that the DB schema actually matches what the entities describe to avoid undetected issues down the line.

I specifically and manually added WEBHOOK_SECRET because it appeared from my perspective that allowing someone to manually export variables and stick it on the front would result in an RCE.