### PR TITLE
Auto-Updating the Staff Deployment Spreadsheet

### DIFF
--- a/.github/workflows/45-sync-a-PR.yml
+++ b/.github/workflows/45-sync-a-PR.yml
@@ -164,7 +164,7 @@ jobs:
           PR_URL: ${{ github.event.inputs.pr_url }}
           GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
         run: |
-          pip3 install -r python/update_staff_deploy_ghsheet-requirements.txt
+          python -m pip install -r python/update_staff_deploy_gsheet-requirements.txt
           python python/update_staff_deploy_gsheet.py --app ${{ env.APP }} --pr_url ${{ env.PR_URL }} --token ${{ env.GITHUB_TOKEN }}
 
       - name: Update deployment status (Failure)

--- a/.github/workflows/45-sync-a-PR.yml
+++ b/.github/workflows/45-sync-a-PR.yml
@@ -10,6 +10,10 @@ on:
       pr_url:
         type: string
         description: URL of a cs156 project repo pull request with a dokku deployment url in the description
+      update_spreadsheet:
+        type: boolean
+        description: Whether to update the deployment spreadsheet
+        default: false
    
 env:
   GITHUB_TOKEN: ${{ secrets.PAT }} # Store your Personal Access Token in Secrets
@@ -157,16 +161,15 @@ jobs:
           log-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} # Link to workflow run logs
 
       - name: Update Deployment Spreadsheet
-        if: success()
+        if: success() && inputs.update_spreadsheet
         env:
           APP: ${{ steps.get_pr_info.outputs.APP }}
-          GITHUB_TOKEN: ${{ secrets.PAT }}
           PR_URL: ${{ github.event.inputs.pr_url }}
           GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
         run: |
           cd python
           python -m pip install -r update_staff_deploy_gsheet-requirements.txt
-          python update_staff_deploy_gsheet.py --app ${{ env.APP }} --pr_url ${{ env.PR_URL }} --token ${{ env.GITHUB_TOKEN }}
+          python update_staff_deploy_gsheet.py --app ${{ env.APP }} --pr_url ${{ env.PR_URL }}
 
       - name: Update deployment status (Failure)
         if: failure()

--- a/.github/workflows/45-sync-a-PR.yml
+++ b/.github/workflows/45-sync-a-PR.yml
@@ -164,8 +164,9 @@ jobs:
           PR_URL: ${{ github.event.inputs.pr_url }}
           GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
         run: |
-          python -m pip install -r python/update_staff_deploy_gsheet-requirements.txt
-          python python/update_staff_deploy_gsheet.py --app ${{ env.APP }} --pr_url ${{ env.PR_URL }} --token ${{ env.GITHUB_TOKEN }}
+          cd python
+          python -m pip install -r update_staff_deploy_gsheet-requirements.txt
+          python update_staff_deploy_gsheet.py --app ${{ env.APP }} --pr_url ${{ env.PR_URL }} --token ${{ env.GITHUB_TOKEN }}
 
       - name: Update deployment status (Failure)
         if: failure()

--- a/.github/workflows/45-sync-a-PR.yml
+++ b/.github/workflows/45-sync-a-PR.yml
@@ -156,6 +156,17 @@ jobs:
           # Optional: Link back to the deployed application
           log-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} # Link to workflow run logs
 
+      - name: Update Deployment Spreadsheet
+        if: success()
+        env:
+          APP: ${{ steps.get_pr_info.outputs.APP }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+          PR_URL: ${{ github.event.inputs.pr_url }}
+          GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+        run: |
+          pip3 install -r python/update_staff_deploy_ghsheet-requirements.txt
+          python python/update_staff_deploy_gsheet.py --app ${{ env.APP }} --pr_url ${{ env.PR_URL }} --token ${{ env.GITHUB_TOKEN }}
+
       - name: Update deployment status (Failure)
         if: failure()
         uses: chrnorm/deployment-status@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+python/credentials.json
+*.idea/

--- a/python/update_staff_deploy_gsheet-requirements.txt
+++ b/python/update_staff_deploy_gsheet-requirements.txt
@@ -1,0 +1,16 @@
+certifi==2026.2.25
+cffi==2.0.0
+charset-normalizer==3.4.5
+cryptography==46.0.5
+google-auth==2.49.0
+google-auth-oauthlib==1.3.0
+gspread==6.2.1
+idna==3.11
+oauthlib==3.3.1
+pyasn1==0.6.2
+pyasn1_modules==0.4.2
+pycparser==3.0
+requests==2.32.5
+requests-oauthlib==2.0.0
+rsa==4.9.1
+urllib3==2.6.3

--- a/python/update_staff_deploy_gsheet.py
+++ b/python/update_staff_deploy_gsheet.py
@@ -5,7 +5,7 @@ import json
 import github_pr_funcs
 
 
-def update(app: str, pr_url: str, token: str):
+def update(app: str, pr_url: str):
     service_account = json.loads(os.getenv('GOOGLE_SERVICE_ACCOUNT'))
     auth = gspread.service_account_from_dict(service_account)
     sheet = auth.open_by_key("1-IQJ0kTyenqZFeS1qeUZvD6oKls2WnlYwSts9IwwtHQ")
@@ -17,15 +17,14 @@ def update(app: str, pr_url: str, token: str):
     if correct_row is None:
         raise ValueError(f"App '{app}' not found in the sheet")
 
-    pr_id = github_pr_funcs.get_pr_from_raw_pr_url(token, pr_url)
+    pr_id = github_pr_funcs.separate_raw_pr_url(pr_url)
 
-    sheet.sheet1.update_cell(correct_row.row, correct_col.col, pr_id)
+    sheet.sheet1.update_cell(correct_row.row, correct_col.col, int(pr_id['pr_number']))
 
 
 parser = argparse.ArgumentParser(description='Update staff deployment Google Sheet')
 parser.add_argument('--app', type=str, help='Dokku app name', required=True)
 parser.add_argument('--pr_url', type=str, help='Pull request url', required=True)
-parser.add_argument('--token', type=str, help='GitHub Token', required=True)
 args = parser.parse_args()
 if __name__ == "__main__":
-    update(args.app, args.pr_url, args.token)
+    update(args.app, args.pr_url)

--- a/python/update_staff_deploy_gsheet.py
+++ b/python/update_staff_deploy_gsheet.py
@@ -1,0 +1,31 @@
+import argparse
+import os
+import gspread
+import json
+import github_pr_funcs
+
+
+def update(app: str, pr_url: str, token: str):
+    service_account = json.loads(os.getenv('GOOGLE_SERVICE_ACCOUNT'))
+    auth = gspread.service_account_from_dict(service_account)
+    sheet = auth.open_by_key("1-IQJ0kTyenqZFeS1qeUZvD6oKls2WnlYwSts9IwwtHQ")
+    correct_col = sheet.sheet1.find('PR')
+    if correct_col is None:
+        raise ValueError("Column 'PR' not found in the sheet")
+
+    correct_row = sheet.sheet1.find(app, case_sensitive=False)
+    if correct_row is None:
+        raise ValueError(f"App '{app}' not found in the sheet")
+
+    pr_id = get_pr_from_raw_pr_url(token, pr_url)
+
+    sheet.sheet1.update_cell(correct_row.row, correct_col.col, pr_id)
+
+
+parser = argparse.ArgumentParser(description='Update staff deployment Google Sheet')
+parser.add_argument('--app', type=str, help='Dokku app name', required=True)
+parser.add_argument('--pr_url', type=str, help='Pull request url', required=True)
+parser.add_argument('--token', type=str, help='GitHub Token', required=True)
+args = parser.parse_args()
+if __name__ == "__main__":
+    update(args.app, args.pr_url, args.token)

--- a/python/update_staff_deploy_gsheet.py
+++ b/python/update_staff_deploy_gsheet.py
@@ -17,7 +17,7 @@ def update(app: str, pr_url: str, token: str):
     if correct_row is None:
         raise ValueError(f"App '{app}' not found in the sheet")
 
-    pr_id = get_pr_from_raw_pr_url(token, pr_url)
+    pr_id = github_pr_funcs.get_pr_from_raw_pr_url(token, pr_url)
 
     sheet.sheet1.update_cell(correct_row.row, correct_col.col, pr_id)
 


### PR DESCRIPTION
In this PR, I create a way to auto-update the staff deployment spreadsheet for Frontiers.

Because other deployments aren't listed, I added this as a workflow input that defaults to false to prevent affecting our other usages of this.

I did so using `Gspread`  and a Google Service account attached to my Google Cloud project.

See a successful run here:
https://github.com/ucsb-cs156/workflows/actions/runs/22840446557

Setup of the Gspread & Auto-update section is documented here: https://ucsb-cs156.github.io/topics/dokku/automatic_deployment_script.html