### PR TITLE
Fix 14-backend-pitest.yml: invalid YAML from stray inputs key + timeout expression syntax

### DIFF
--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -13,7 +13,6 @@ on:
         required: false
         type: string
         default: 'temurin'
-         inputs:
       TIMEOUT:
         required: false
         type: number
@@ -29,7 +28,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: ${inputs.TIMEOUT}
+    timeout-minutes: ${{ inputs.TIMEOUT }}
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The recent TIMEOUT addition (9993236) left two problems in `14-backend-pitest.yml`:

1. **A stray, mis-indented `inputs:` line** inside the `JAVA_DISTRIBUTION` block, which makes the whole file invalid YAML. Every caller repo's `14-backend-pitest` run has been failing at startup with "This run likely failed because of a workflow file issue" since — including on their `main` branches (verified in proj-scaffold: failures on every branch since the change).
2. **`timeout-minutes: ${inputs.TIMEOUT}`** uses shell-style interpolation; GitHub Actions needs the expression syntax `${{ inputs.TIMEOUT }}`. (This one would have bitten only after the YAML itself parsed.)

Both fixed; the file now parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)